### PR TITLE
Adding podspec

### DIFF
--- a/JTSSloppySwiping.podspec
+++ b/JTSSloppySwiping.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "JTSSloppySwiping"
+  s.version      = "0.0.1"
+  s.summary      = "Drop-in UINavigationControllerDelegate that enables sloppy swiping."
+
+  s.homepage     = "https://github.com/jaredsinclair/JTSSloppySwiping"
+  s.license      = "MIT"
+  s.author       = { "Jared Sinclair" => "desk@jaredsinclair.com" }
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/jaredsinclair/JTSSloppySwiping.git", :commit => "9aa60dce36a3f957f262f121de2a0b34316109d0" }
+
+  s.source_files  = "JTSSloppySwiping/**/*.swift"
+  s.framework  = "UIKit"
+  s.requires_arc = true
+end


### PR DESCRIPTION
I’ve recently added [JTSSloppySwiping](https://github.com/CocoaPods/Specs/tree/master/JTSSloppySwiping) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, JTSSloppySwiping doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
