### PR TITLE
Make SloppyNavigationController open

### DIFF
--- a/JTSSloppySwiping/JTSSloppySwiping.swift
+++ b/JTSSloppySwiping/JTSSloppySwiping.swift
@@ -15,7 +15,7 @@ import UIKit
 /// controller's delegate (or forwarding the relevant methods from an existing
 /// delegate), and keeping a strong reference to the SloppySwiping instance.
 @objc(JTSSloppyNavigationController)
-public class SloppyNavigationController: UINavigationController {
+open class SloppyNavigationController: UINavigationController {
     
     // MARK: Private Properties
     


### PR DESCRIPTION
This covers the use case where you have a `UINavigationController` subclass, and you want to use this library. With the `public` access level, I can't change the `UINavigationController` subclass to `SloppyNavigationController`.